### PR TITLE
Fixed replication key issue

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -6,7 +6,8 @@ on:
       - 'main'
 
 jobs:
-  pipeline:
+  tap-nhl-cicd:
+    name: tap-nhl-cicd
     runs-on: ubuntu-latest
     env:
       python-version: 3.8.12

--- a/meltano.yml
+++ b/meltano.yml
@@ -20,10 +20,12 @@ plugins:
       env: DRAFT_YEAR_START
     - name: draft_year_end
       env: DRAFT_YEAR_END
+    config:
+      start_date: "2021-01-01T00:00:00Z"
   loaders:
   - name: target-bigquery
     variant: adswerve
-    pip_url: git+https://github.com/adswerve/target-bigquery.git@v0.12.0
+    pip_url: git+https://github.com/adswerve/target-bigquery.git@0.12.2
     config:
       add_metadata_columns: true
       project_id: nhl-breakouts


### PR DESCRIPTION
- Fixes replication key issue where `gameDate` was used instead of `scheduleDate`, resulting in the wrong date being used for state
- Updated tap-bigquery version to 0.12.2